### PR TITLE
Fix Composer RuntimeException

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require-dev": {
         "phpunit/phpunit": "<=4",
         "friendsofphp/php-cs-fixer": "^2.1",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsstream": "^1.6"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Fixes a Composer RuntimeException caused by an invalid package name.

This appears to be holding up the latest update to packgist (it's currently stuck on 2.0 from 2016).